### PR TITLE
Babel transform runtime and no amd

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -99,7 +99,7 @@ module.exports = {
               require.resolve('babel-plugin-transform-runtime'),
               {
                 helpers: false,
-                polyfill: false,
+                polyfill: process.env.BABEL_TRANSFORM_RUNTIME_POLYFILL === 'true' ? true : false,
                 regenerator: true
               }
             ]

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -141,9 +141,19 @@ module.exports = {
           {
             loader: require.resolve('string-replace-loader'),
             query: {
-              search: '%PUBLIC_URL%',
-              replace: publicUrl,
-              flags: 'g'
+              multiple: [
+                {
+                  search: '%PUBLIC_URL%',
+                  replace: publicUrl,
+                  flags: 'g'
+                },
+                // remove AMD registration from elm-make output https://github.com/elm-lang/elm-make/blob/2cf040aa801d195fc6db52a5cdb7f5da0ae42c5e/src/Pipeline/Generate.hs#L264
+                {
+                  search: /^if \(typeof define === "function" && define\['amd']\)(.*\n){6}/,
+                  replace: '',
+                  flags: 'gm'
+                }
+              ]
             }
           },
           {

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -122,7 +122,7 @@ module.exports = {
               require.resolve('babel-plugin-transform-runtime'),
               {
                 helpers: false,
-                polyfill: false,
+                polyfill: process.env.BABEL_TRANSFORM_RUNTIME_POLYFILL === 'true' ? true : false,
                 regenerator: true
               }
             ]

--- a/template/README.md
+++ b/template/README.md
@@ -1,4 +1,4 @@
-#transform-runtime Elm App
+# Elm App
 
 This project is bootstrapped with [Create Elm App](https://github.com/halfzebra/create-elm-app).
 

--- a/template/README.md
+++ b/template/README.md
@@ -1,4 +1,4 @@
-# Elm App
+#transform-runtime Elm App
 
 This project is bootstrapped with [Create Elm App](https://github.com/halfzebra/create-elm-app).
 
@@ -49,6 +49,7 @@ You can find the most recent version of this guide [here](https://github.com/hal
   * [Static Server](#static-server)
   * [GitHub Pages](#github-pages)
 * [IDE setup for Hot Module Replacement](#ide-setup-for-hot-module-replacement)
+* [Babel Transform Runtime plugin options](#babel-transform-runtime-plugin-options)
 
 ## Sending feedback
 
@@ -850,3 +851,10 @@ GitHub Pages doesn’t support routers that use the HTML5 `pushState` history AP
 ## IDE setup for Hot Module Replacement
 
 Remember to disable [safe write](https://webpack.github.io/docs/webpack-dev-server.html#working-with-editors-ides-supporting-safe-write) if you are using VIM or IntelliJ IDE, such as WebStorm.
+
+## Babel Transform Runtime plugin options
+
+By default, Babel Transform Runtime plugin is configured to **not** transform new built-ins (Promise, Set, Map, etc.) to use a non-global polluting polyfill ([Babel Runtime transform plugin documentation](https://babeljs.io/docs/plugins/transform-runtime/)).
+
+To enable this transformation set `BABEL_TRANSFORM_RUNTIME_POLYFILL` environment variable to `true` or `false` respectively.
+

--- a/template/README.md
+++ b/template/README.md
@@ -856,5 +856,5 @@ Remember to disable [safe write](https://webpack.github.io/docs/webpack-dev-serv
 
 By default, Babel Transform Runtime plugin is configured to **not** transform new built-ins (Promise, Set, Map, etc.) to use a non-global polluting polyfill ([Babel Runtime transform plugin documentation](https://babeljs.io/docs/plugins/transform-runtime/)).
 
-To enable this transformation set `BABEL_TRANSFORM_RUNTIME_POLYFILL` environment variable to `true` or `false` respectively.
+To enable this transformation set `BABEL_TRANSFORM_RUNTIME_POLYFILL` environment variable to `true`.
 


### PR DESCRIPTION
We've been using this babel-plugin-transform-runtime for years so might as well just merge it to master
